### PR TITLE
#00005-TOL AWS CLIを実行できる開発用コンテナを追加

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,3 @@
+FROM amazon/aws-cli:2.11.0
+
+CMD [ "/bin/bash", "-login" ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/alpine
+{
+	"name": "awscli",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"build": {
+		"dockerfile": "Dockerfile"
+	}
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}


### PR DESCRIPTION
# Description

## Issue Number

#5

## What's Changed

プルリクエストで実施したことと実施状況を記載してください

- [x] amazon/aws-cli:2.11.0をベースとしたdevcontainerを追加
- [x] `aws --version` を実施できることを確認

## Remark

MFA認証のトークン取得は手動で実施する必要がある。
